### PR TITLE
Link explicitly against libcrypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "openssl-engine-kms"
 version = "0.1.0"
 authors = ["Nuutti Kotivuori <naked@iki.fi>"]
 edition = "2018"
+links = "crypto"
 
 [dependencies]
 libc = "*"
@@ -13,7 +14,6 @@ env_logger = "*"
 # rustls used because it is difficult to properly use openssl inside openssl engine
 rusoto_core = { git = "https://github.com/rusoto/rusoto", default_features = false, features=["rustls"] }
 rusoto_kms = { git = "https://github.com/rusoto/rusoto", default_features = false, features=["rustls"] }
-
 
 [lib]
 name = "openssl_engine_kms"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    println!("cargo:rustc-link-lib=crypto");
+    println!("cargo:rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
Builtin engines (capi and co) do link against libcrypto, and it is a requirement to be able to use your engine with pyca/cryptography